### PR TITLE
Feature oauth authorizer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "aws-sdk": "^2.1223.0",
         "axios": "^0.27.2",
+        "jwt-decode": "^3.1.2",
         "pg": "^8.8.0",
         "pg-hstore": "^2.3.4",
         "sequelize": "^6.23.1",
@@ -2941,6 +2942,11 @@
         "follow-redirects": "^1.14.0"
       }
     },
+    "node_modules/@serverless/platform-client/node_modules/jwt-decode": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
+      "integrity": "sha512-86GgN2vzfUu7m9Wcj63iUkuDzFNYFVmjeDm2GzWpUk+opB0pEpMsw6ePCMrhYkumz2C1ihqtZzOMAg7FiXcNoQ=="
+    },
     "node_modules/@serverless/platform-client/node_modules/querystring": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
@@ -3007,11 +3013,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/@serverless/utils/node_modules/jwt-decode": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "node_modules/@serverless/utils/node_modules/supports-color": {
       "version": "8.1.1",
@@ -10821,9 +10822,9 @@
       }
     },
     "node_modules/jwt-decode": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
-      "integrity": "sha512-86GgN2vzfUu7m9Wcj63iUkuDzFNYFVmjeDm2GzWpUk+opB0pEpMsw6ePCMrhYkumz2C1ihqtZzOMAg7FiXcNoQ=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "node_modules/keyv": {
       "version": "4.5.0",
@@ -19826,6 +19827,11 @@
             "follow-redirects": "^1.14.0"
           }
         },
+        "jwt-decode": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
+          "integrity": "sha512-86GgN2vzfUu7m9Wcj63iUkuDzFNYFVmjeDm2GzWpUk+opB0pEpMsw6ePCMrhYkumz2C1ihqtZzOMAg7FiXcNoQ=="
+        },
         "querystring": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
@@ -19884,11 +19890,6 @@
           "requires": {
             "argparse": "^2.0.1"
           }
-        },
-        "jwt-decode": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-          "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
         },
         "supports-color": {
           "version": "8.1.1",
@@ -25818,9 +25819,9 @@
       }
     },
     "jwt-decode": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
-      "integrity": "sha512-86GgN2vzfUu7m9Wcj63iUkuDzFNYFVmjeDm2GzWpUk+opB0pEpMsw6ePCMrhYkumz2C1ihqtZzOMAg7FiXcNoQ=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "keyv": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.0.1",
     "nodemon": "^2.0.20",
-    "serverless-bundle": "^5.5.0",
     "sequelize-cli": "^6.5.1",
+    "serverless-bundle": "^5.5.0",
     "serverless-dotenv": "^1.0.0-beta.2",
     "serverless-dotenv-plugin": "^4.0.2",
     "serverless-offline": "^10.2.1",
@@ -36,6 +36,7 @@
   "dependencies": {
     "aws-sdk": "^2.1223.0",
     "axios": "^0.27.2",
+    "jwt-decode": "^3.1.2",
     "pg": "^8.8.0",
     "pg-hstore": "^2.3.4",
     "sequelize": "^6.23.1",

--- a/src/functions/tickets_crud/createTicket.js
+++ b/src/functions/tickets_crud/createTicket.js
@@ -4,18 +4,18 @@ import { getUserEmail } from '../../utils/getUserEmail'
 import { sanitizeBody } from '../../utils/sanitizeBody'
 
 export const createTicket = async (event) => {
-  let userEmail = null;
+  let userEmail = null
   try {
-    userEmail = getUserEmail(event);
+    userEmail = getUserEmail(event)
   } catch (error) {
     return errorResponse('Unauthorized: email not present in JWT', 401)
   }
 
-  const body =  sanitizeBody(JSON.parse(event.body))
+  const body = sanitizeBody(JSON.parse(event.body))
   const orm = await loadORM()
 
   try {
-    const ticket = await orm.Ticket.create({...body, userEmail}, 201)
+    const ticket = await orm.Ticket.create({ ...body, userEmail }, 201)
     return succesfullResponse(ticket)
   } catch (error) {
     console.log(error)

--- a/src/functions/tickets_crud/createTicket.js
+++ b/src/functions/tickets_crud/createTicket.js
@@ -15,8 +15,8 @@ export const createTicket = async (event) => {
   const orm = await loadORM()
 
   try {
-    const ticket = await orm.Ticket.create({ ...body, userEmail }, 201)
-    return succesfullResponse(ticket)
+    const ticket = await orm.Ticket.create({ ...body, userEmail })
+    return succesfullResponse(ticket, 201)
   } catch (error) {
     return errorResponse('Ticket could not be created', 400)
   }

--- a/src/functions/tickets_crud/createTicket.js
+++ b/src/functions/tickets_crud/createTicket.js
@@ -1,13 +1,21 @@
 import { succesfullResponse, errorResponse } from '../../utils/response_util'
 import { loadORM } from '../../config/sequelize'
+import { getUserEmail } from '../../utils/getUserEmail'
+import { sanitizeBody } from '../../utils/sanitizeBody'
 
 export const createTicket = async (event) => {
-  // TO DO: Parse user email from token and attach to body
-  const body = JSON.parse(event.body)
+  let userEmail = null;
+  try {
+    userEmail = getUserEmail(event);
+  } catch (error) {
+    return errorResponse('Unauthorized: email not present in JWT', 401)
+  }
+
+  const body =  sanitizeBody(JSON.parse(event.body))
   const orm = await loadORM()
 
   try {
-    const ticket = await orm.Ticket.create(body, 201)
+    const ticket = await orm.Ticket.create({...body, userEmail}, 201)
     return succesfullResponse(ticket)
   } catch (error) {
     console.log(error)

--- a/src/functions/tickets_crud/deleteTicket.js
+++ b/src/functions/tickets_crud/deleteTicket.js
@@ -1,13 +1,24 @@
 import { succesfullResponse, errorResponse } from '../../utils/response_util'
 import { loadORM } from '../../config/sequelize'
+import { getUserEmail } from '../../utils/getUserEmail'
 
 export const deleteTicket = async (event, context, callback) => {
+  let userEmail = null;
+  try {
+    userEmail = getUserEmail(event);
+  } catch (error) {
+    return errorResponse('Unauthorized: email not present in JWT', 401)
+  }
+
   const id = event.pathParameters.id
   const orm = await loadORM()
   const ticket = await orm.Ticket.findByPk(id)
 
   if (!ticket) {
     return errorResponse('Ticket could not be found', 404)
+  }
+  if (ticket.userEmail != userEmail) {
+    return errorResponse('Forbidden', 403)
   }
   try {
     await ticket.destroy()

--- a/src/functions/tickets_crud/deleteTicket.js
+++ b/src/functions/tickets_crud/deleteTicket.js
@@ -3,9 +3,9 @@ import { loadORM } from '../../config/sequelize'
 import { getUserEmail } from '../../utils/getUserEmail'
 
 export const deleteTicket = async (event, context, callback) => {
-  let userEmail = null;
+  let userEmail = null
   try {
-    userEmail = getUserEmail(event);
+    userEmail = getUserEmail(event)
   } catch (error) {
     return errorResponse('Unauthorized: email not present in JWT', 401)
   }
@@ -17,7 +17,7 @@ export const deleteTicket = async (event, context, callback) => {
   if (!ticket) {
     return errorResponse('Ticket could not be found', 404)
   }
-  if (ticket.userEmail != userEmail) {
+  if (ticket.userEmail !== userEmail) {
     return errorResponse('Forbidden', 403)
   }
   try {

--- a/src/functions/tickets_crud/getTickets.js
+++ b/src/functions/tickets_crud/getTickets.js
@@ -1,8 +1,19 @@
-import { succesfullResponse } from '../../utils/response_util'
+import { succesfullResponse, errorResponse } from '../../utils/response_util'
 import { loadORM } from '../../config/sequelize'
+import { getUserEmail } from '../../utils/getUserEmail'
 
 export const getTickets = async (event, context, callback) => {
+  let userEmail = null;
+  try {
+    userEmail = getUserEmail(event);
+  } catch (error) {
+    return errorResponse('Unauthorized: email not present in JWT', 401)
+  }
+
   const orm = await loadORM()
-  const tickets = await orm.Ticket.findAll({ include: { model: orm.Comment } })
+  const tickets = await orm.Ticket.findAll({
+    where: { userEmail },
+    include: { model: orm.Comment }
+  })
   return succesfullResponse(tickets)
 }

--- a/src/functions/tickets_crud/getTickets.js
+++ b/src/functions/tickets_crud/getTickets.js
@@ -3,9 +3,9 @@ import { loadORM } from '../../config/sequelize'
 import { getUserEmail } from '../../utils/getUserEmail'
 
 export const getTickets = async (event, context, callback) => {
-  let userEmail = null;
+  let userEmail = null
   try {
-    userEmail = getUserEmail(event);
+    userEmail = getUserEmail(event)
   } catch (error) {
     return errorResponse('Unauthorized: email not present in JWT', 401)
   }

--- a/src/functions/tickets_crud/readTicket.js
+++ b/src/functions/tickets_crud/readTicket.js
@@ -1,13 +1,26 @@
 import { succesfullResponse, errorResponse } from '../../utils/response_util'
 import { loadORM } from '../../config/sequelize'
+import { getUserEmail } from '../../utils/getUserEmail'
 
 export const readTicket = async (event, context, callback) => {
+  let userEmail = null;
+  try {
+    userEmail = getUserEmail(event);
+  } catch (error) {
+    return errorResponse('Unauthorized: email not present in JWT', 401)
+  }
+
   const id = event.pathParameters.id
   console.log(id)
   const orm = await loadORM()
   const ticket = await orm.Ticket.findByPk(id, { include: { model: orm.Comment } })
-  if (ticket) {
-    return succesfullResponse(ticket)
+
+  if (!ticket) {
+    return errorResponse('Ticket not found', 404)
   }
-  errorResponse('Ticket not found', 404)
+  if (ticket.userEmail != userEmail) {
+    return errorResponse('Forbidden', 403)
+  }
+
+  return succesfullResponse(ticket)
 }

--- a/src/functions/tickets_crud/readTicket.js
+++ b/src/functions/tickets_crud/readTicket.js
@@ -3,9 +3,9 @@ import { loadORM } from '../../config/sequelize'
 import { getUserEmail } from '../../utils/getUserEmail'
 
 export const readTicket = async (event, context, callback) => {
-  let userEmail = null;
+  let userEmail = null
   try {
-    userEmail = getUserEmail(event);
+    userEmail = getUserEmail(event)
   } catch (error) {
     return errorResponse('Unauthorized: email not present in JWT', 401)
   }
@@ -18,7 +18,7 @@ export const readTicket = async (event, context, callback) => {
   if (!ticket) {
     return errorResponse('Ticket not found', 404)
   }
-  if (ticket.userEmail != userEmail) {
+  if (ticket.userEmail !== userEmail) {
     return errorResponse('Forbidden', 403)
   }
 

--- a/src/functions/tickets_crud/updateTicket.js
+++ b/src/functions/tickets_crud/updateTicket.js
@@ -4,9 +4,9 @@ import { sanitizeBody } from '../../utils/sanitizeBody'
 import { getUserEmail } from '../../utils/getUserEmail'
 
 export const updateTicket = async (event) => {
-  let userEmail = null;
+  let userEmail = null
   try {
-    userEmail = getUserEmail(event);
+    userEmail = getUserEmail(event)
   } catch (error) {
     return errorResponse('Unauthorized: email not present in JWT', 401)
   }
@@ -20,7 +20,7 @@ export const updateTicket = async (event) => {
   if (!ticket) {
     return errorResponse('Ticket not found', 404)
   }
-  if (ticket.userEmail != userEmail) {
+  if (ticket.userEmail !== userEmail) {
     return errorResponse('Forbidden', 403)
   }
 

--- a/src/functions/tickets_crud/updateTicket.js
+++ b/src/functions/tickets_crud/updateTicket.js
@@ -1,8 +1,16 @@
 import { succesfullResponse, errorResponse } from '../../utils/response_util'
 import { loadORM } from '../../config/sequelize'
 import { sanitizeBody } from '../../utils/sanitizeBody'
+import { getUserEmail } from '../../utils/getUserEmail'
 
 export const updateTicket = async (event) => {
+  let userEmail = null;
+  try {
+    userEmail = getUserEmail(event);
+  } catch (error) {
+    return errorResponse('Unauthorized: email not present in JWT', 401)
+  }
+
   const id = event.pathParameters.id
   const body = sanitizeBody(JSON.parse(event.body))
 
@@ -11,6 +19,9 @@ export const updateTicket = async (event) => {
 
   if (!ticket) {
     return errorResponse('Ticket not found', 404)
+  }
+  if (ticket.userEmail != userEmail) {
+    return errorResponse('Forbidden', 403)
   }
 
   try {

--- a/src/tests/utils/getUserEmail.test.js
+++ b/src/tests/utils/getUserEmail.test.js
@@ -1,0 +1,249 @@
+import { getUserEmail } from '../../utils/getUserEmail'
+
+describe('getUserEmail', () => {
+  it('Gets the user email from API gateway event', () => {
+    /**
+    * The following jwt have this payload:
+    * {
+    *   "email": "g4-capstone@pinflag.cl",
+    *   "iss": "https://dev-nh2svhzc.us.auth0.com/",
+    *   "sub": "PIekrRjxXNJim7QblTwZcwWSM92Q5j8p@clients",
+    *   "aud": "https://9shjd4c13a.execute-api.sa-east-1.amazonaws.com/dev",
+    *   "iat": 1664640904,
+    *   "exp": 1664727304,
+    *   "azp": "PIekrRjxXNJim7QblTwZcwWSM92Q5j8p",
+    *   "gty": "client-credentials"
+    * }
+    */
+    const event = {
+      body: null,
+      headers: {
+        Authorization: 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6Imc0LWNhcHN0b25lQHBpbmZsYWcuY2wiLCJpc3MiOiJodHRwczovL2Rldi1uaDJzdmh6Yy51cy5hdXRoMC5jb20vIiwic3ViIjoiUElla3JSanhYTkppbTdRYmxUd1pjd1dTTTkyUTVqOHBAY2xpZW50cyIsImF1ZCI6Imh0dHBzOi8vOXNoamQ0YzEzYS5leGVjdXRlLWFwaS5zYS1lYXN0LTEuYW1hem9uYXdzLmNvbS9kZXYiLCJpYXQiOjE2NjQ2NDA5MDQsImV4cCI6MTY2NDcyNzMwNCwiYXpwIjoiUElla3JSanhYTkppbTdRYmxUd1pjd1dTTTkyUTVqOHAiLCJndHkiOiJjbGllbnQtY3JlZGVudGlhbHMifQ.qm7QQPEYNPy0ZyxtPgadm65PJwkBhf3A_L8Dp6dKm7o',
+        'User-Agent': 'PostmanRuntime/7.29.2',
+        Accept: '*/*',
+        'Cache-Control': 'no-cache',
+        'Postman-Token': 'c3ec1ad0-ca61-401a-bc4a-231b7acfe3c4',
+        Host: 'localhost:3000',
+        'Accept-Encoding': 'gzip, deflate, br',
+        Connection: 'keep-alive'
+      },
+      httpMethod: 'GET',
+      isBase64Encoded: false,
+      multiValueHeaders: {
+        Authorization: [
+          'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6Imc0LWNhcHN0b25lQHBpbmZsYWcuY2wiLCJpc3MiOiJodHRwczovL2Rldi1uaDJzdmh6Yy51cy5hdXRoMC5jb20vIiwic3ViIjoiUElla3JSanhYTkppbTdRYmxUd1pjd1dTTTkyUTVqOHBAY2xpZW50cyIsImF1ZCI6Imh0dHBzOi8vOXNoamQ0YzEzYS5leGVjdXRlLWFwaS5zYS1lYXN0LTEuYW1hem9uYXdzLmNvbS9kZXYiLCJpYXQiOjE2NjQ2NDA5MDQsImV4cCI6MTY2NDcyNzMwNCwiYXpwIjoiUElla3JSanhYTkppbTdRYmxUd1pjd1dTTTkyUTVqOHAiLCJndHkiOiJjbGllbnQtY3JlZGVudGlhbHMifQ.qm7QQPEYNPy0ZyxtPgadm65PJwkBhf3A_L8Dp6dKm7o'
+        ],
+        'User-Agent': ['PostmanRuntime/7.29.2'],
+        Accept: ['*/*'],
+        'Cache-Control': ['no-cache'],
+        'Postman-Token': ['c3ec1ad0-ca61-401a-bc4a-231b7acfe3c4'],
+        Host: ['localhost:3000'],
+        'Accept-Encoding': ['gzip, deflate, br'],
+        Connection: ['keep-alive']
+      },
+      multiValueQueryStringParameters: null,
+      path: '/tickets',
+      pathParameters: null,
+      queryStringParameters: null,
+      requestContext: {
+        accountId: 'offlineContext_accountId',
+        apiId: 'offlineContext_apiId',
+        authorizer: {
+          claims: [Object],
+          principalId: 'offlineContext_authorizer_principalId',
+          scopes: undefined
+        },
+        domainName: 'offlineContext_domainName',
+        domainPrefix: 'offlineContext_domainPrefix',
+        extendedRequestId: 'd888b55c-d67d-4e10-b799-f7e6177a2300',
+        httpMethod: 'GET',
+        identity: {
+          accessKey: null,
+          accountId: 'offlineContext_accountId',
+          apiKey: 'offlineContext_apiKey',
+          apiKeyId: 'offlineContext_apiKeyId',
+          caller: 'offlineContext_caller',
+          cognitoAuthenticationProvider: 'offlineContext_cognitoAuthenticationProvider',
+          cognitoAuthenticationType: 'offlineContext_cognitoAuthenticationType',
+          cognitoIdentityId: 'offlineContext_cognitoIdentityId',
+          cognitoIdentityPoolId: 'offlineContext_cognitoIdentityPoolId',
+          principalOrgId: null,
+          sourceIp: '127.0.0.1',
+          user: 'offlineContext_user',
+          userAgent: 'PostmanRuntime/7.29.2',
+          userArn: 'offlineContext_userArn'
+        },
+        operationName: undefined,
+        path: '/tickets',
+        protocol: 'HTTP/1.1',
+        requestId: '58faece6-a4fe-4fe3-a8a2-c5eb6e95b550',
+        requestTime: '01/Oct/2022:13:17:37 -0300',
+        requestTimeEpoch: 1664641057188,
+        resourceId: 'offlineContext_resourceId',
+        resourcePath: '/dev/tickets',
+        stage: 'dev'
+      },
+      resource: '/tickets',
+      stageVariables: null
+    }
+    expect(getUserEmail(event)).toBe('g4-capstone@pinflag.cl')
+  })
+
+  it('Throws error if there is no token in the event', () => {
+    const event = {
+      body: null,
+      headers: {
+        'User-Agent': 'PostmanRuntime/7.29.2',
+        Accept: '*/*',
+        'Cache-Control': 'no-cache',
+        'Postman-Token': 'acd2161d-aecb-4a6a-a57e-150292111cb4',
+        Host: 'localhost:3000',
+        'Accept-Encoding': 'gzip, deflate, br',
+        Connection: 'keep-alive'
+      },
+      httpMethod: 'GET',
+      isBase64Encoded: false,
+      multiValueHeaders: {
+        'User-Agent': ['PostmanRuntime/7.29.2'],
+        Accept: ['*/*'],
+        'Cache-Control': ['no-cache'],
+        'Postman-Token': ['acd2161d-aecb-4a6a-a57e-150292111cb4'],
+        Host: ['localhost:3000'],
+        'Accept-Encoding': ['gzip, deflate, br'],
+        Connection: ['keep-alive']
+      },
+      multiValueQueryStringParameters: null,
+      path: '/tickets',
+      pathParameters: null,
+      queryStringParameters: null,
+      requestContext: {
+        accountId: 'offlineContext_accountId',
+        apiId: 'offlineContext_apiId',
+        authorizer: {
+          claims: undefined,
+          principalId: 'offlineContext_authorizer_principalId',
+          scopes: undefined
+        },
+        domainName: 'offlineContext_domainName',
+        domainPrefix: 'offlineContext_domainPrefix',
+        extendedRequestId: '6643b2b3-45ec-424b-90ba-4127155dcf6d',
+        httpMethod: 'GET',
+        identity: {
+          accessKey: null,
+          accountId: 'offlineContext_accountId',
+          apiKey: 'offlineContext_apiKey',
+          apiKeyId: 'offlineContext_apiKeyId',
+          caller: 'offlineContext_caller',
+          cognitoAuthenticationProvider: 'offlineContext_cognitoAuthenticationProvider',
+          cognitoAuthenticationType: 'offlineContext_cognitoAuthenticationType',
+          cognitoIdentityId: 'offlineContext_cognitoIdentityId',
+          cognitoIdentityPoolId: 'offlineContext_cognitoIdentityPoolId',
+          principalOrgId: null,
+          sourceIp: '127.0.0.1',
+          user: 'offlineContext_user',
+          userAgent: 'PostmanRuntime/7.29.2',
+          userArn: 'offlineContext_userArn'
+        },
+        operationName: undefined,
+        path: '/tickets',
+        protocol: 'HTTP/1.1',
+        requestId: 'e614c11d-d87d-4e6a-89c2-c496a499a577',
+        requestTime: '01/Oct/2022:13:26:59 -0300',
+        requestTimeEpoch: 1664641619250,
+        resourceId: 'offlineContext_resourceId',
+        resourcePath: '/dev/tickets',
+        stage: 'dev'
+      },
+      resource: '/tickets',
+      stageVariables: null
+    }
+    expect(() => getUserEmail(event)).toThrow()
+  })
+
+  it('Throws error if there is no email in the jwt', () => {
+    /**
+    * The following jwt have this payload:
+    * {
+    *   "iss": "https://dev-nh2svhzc.us.auth0.com/",
+    *   "sub": "PIekrRjxXNJim7QblTwZcwWSM92Q5j8p@clients",
+    *   "aud": "https://9shjd4c13a.execute-api.sa-east-1.amazonaws.com/dev",
+    *   "iat": 1664640904,
+    *   "exp": 1664727304,
+    *   "azp": "PIekrRjxXNJim7QblTwZcwWSM92Q5j8p",
+    *   "gty": "client-credentials"
+    * }
+    */
+    const event = {
+      body: null,
+      headers: {
+        Authorization: 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2Rldi1uaDJzdmh6Yy51cy5hdXRoMC5jb20vIiwic3ViIjoiUElla3JSanhYTkppbTdRYmxUd1pjd1dTTTkyUTVqOHBAY2xpZW50cyIsImF1ZCI6Imh0dHBzOi8vOXNoamQ0YzEzYS5leGVjdXRlLWFwaS5zYS1lYXN0LTEuYW1hem9uYXdzLmNvbS9kZXYiLCJpYXQiOjE2NjQ2NDA5MDQsImV4cCI6MTY2NDcyNzMwNCwiYXpwIjoiUElla3JSanhYTkppbTdRYmxUd1pjd1dTTTkyUTVqOHAiLCJndHkiOiJjbGllbnQtY3JlZGVudGlhbHMifQ.Q7UA4kP36dy2V3cYRYV5FhfiW4lZuxT8BE1yiRPL3tk',
+        'User-Agent': 'PostmanRuntime/7.29.2',
+        Accept: '*/*',
+        'Cache-Control': 'no-cache',
+        'Postman-Token': '6a5ed950-6f23-46fb-a6a7-6df091828c7c',
+        Host: 'localhost:3000',
+        'Accept-Encoding': 'gzip, deflate, br',
+        Connection: 'keep-alive'
+      },
+      httpMethod: 'GET',
+      isBase64Encoded: false,
+      multiValueHeaders: {
+        Authorization: [
+          'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2Rldi1uaDJzdmh6Yy51cy5hdXRoMC5jb20vIiwic3ViIjoiUElla3JSanhYTkppbTdRYmxUd1pjd1dTTTkyUTVqOHBAY2xpZW50cyIsImF1ZCI6Imh0dHBzOi8vOXNoamQ0YzEzYS5leGVjdXRlLWFwaS5zYS1lYXN0LTEuYW1hem9uYXdzLmNvbS9kZXYiLCJpYXQiOjE2NjQ2NDA5MDQsImV4cCI6MTY2NDcyNzMwNCwiYXpwIjoiUElla3JSanhYTkppbTdRYmxUd1pjd1dTTTkyUTVqOHAiLCJndHkiOiJjbGllbnQtY3JlZGVudGlhbHMifQ.Q7UA4kP36dy2V3cYRYV5FhfiW4lZuxT8BE1yiRPL3tk'
+        ],
+        'User-Agent': ['PostmanRuntime/7.29.2'],
+        Accept: ['*/*'],
+        'Cache-Control': ['no-cache'],
+        'Postman-Token': ['6a5ed950-6f23-46fb-a6a7-6df091828c7c'],
+        Host: ['localhost:3000'],
+        'Accept-Encoding': ['gzip, deflate, br'],
+        Connection: ['keep-alive']
+      },
+      multiValueQueryStringParameters: null,
+      path: '/tickets',
+      pathParameters: null,
+      queryStringParameters: null,
+      requestContext: {
+        accountId: 'offlineContext_accountId',
+        apiId: 'offlineContext_apiId',
+        authorizer: {
+          claims: [Object],
+          principalId: 'offlineContext_authorizer_principalId',
+          scopes: undefined
+        },
+        domainName: 'offlineContext_domainName',
+        domainPrefix: 'offlineContext_domainPrefix',
+        extendedRequestId: '38068044-0630-4397-ae44-d1d3c4b46a14',
+        httpMethod: 'GET',
+        identity: {
+          accessKey: null,
+          accountId: 'offlineContext_accountId',
+          apiKey: 'offlineContext_apiKey',
+          apiKeyId: 'offlineContext_apiKeyId',
+          caller: 'offlineContext_caller',
+          cognitoAuthenticationProvider: 'offlineContext_cognitoAuthenticationProvider',
+          cognitoAuthenticationType: 'offlineContext_cognitoAuthenticationType',
+          cognitoIdentityId: 'offlineContext_cognitoIdentityId',
+          cognitoIdentityPoolId: 'offlineContext_cognitoIdentityPoolId',
+          principalOrgId: null,
+          sourceIp: '127.0.0.1',
+          user: 'offlineContext_user',
+          userAgent: 'PostmanRuntime/7.29.2',
+          userArn: 'offlineContext_userArn'
+        },
+        operationName: undefined,
+        path: '/tickets',
+        protocol: 'HTTP/1.1',
+        requestId: '9ca53363-5f69-4b41-97bb-3953f346011d',
+        requestTime: '01/Oct/2022:13:33:45 -0300',
+        requestTimeEpoch: 1664642025924,
+        resourceId: 'offlineContext_resourceId',
+        resourcePath: '/dev/tickets',
+        stage: 'dev'
+      },
+      resource: '/tickets',
+      stageVariables: null
+    }
+    expect(() => getUserEmail(event)).toThrow()
+  })
+})

--- a/src/utils/getUserEmail.js
+++ b/src/utils/getUserEmail.js
@@ -1,0 +1,11 @@
+import jwtDecode from 'jwt-decode'
+
+function getUserEmail (event) {
+  const email = jwtDecode(event.headers.Authorization).email
+  if (!email) {
+    throw Error('Invalid Token, email claim is not present')
+  }
+  return email
+}
+
+export { getUserEmail }


### PR DESCRIPTION
## Description
- Added JWT decoding to get the email of the user that request the API. 
- Created flows in the `/tickets` endpoints to throw errors according to the requests
- Created `401` error response if the `email` is not provided in the JWT.
- Created `403` error response when a user tries to access a ticket that does not belongs to him
- List of tickets now return just the tickets that belongs to the user that request the resource
### Motivation
- Filter tickets by user.
- Block access to users that does not own the resource.
- Block access when a request does not have the required claims (email) in the JWT.

Why i want to merge these changes?
To make the api secure and client dependant.

### Summary
- Added 2 conditionals in each endpoint to throw `401: Unauthorized` and `403: Forbidden` accordly
- Creaeted a util function `getUserEmail(event)` that returns the user email from the JWT of the event, or throws error if the email is not present.

## Checklist:

- [X] This PR has latest changes from main branch (git merge origin/main)
- [X] This PR was self-reviewed (Check your changes before asking for review)
- [X] This PR was documented (particularly in hard-to-understand areas)
- [ ] This PR updates the technical documentation (under /docs)
- [ ] This PR requires new deployment configurations
- [ ] This PR has migrations pointing to the latest revision in target branch
- [X] This PR has test cases for every change made
- [X] This PR passed all previous tests
